### PR TITLE
Initialize Prisma with environment-based datasource

### DIFF
--- a/my-app/.env
+++ b/my-app/.env
@@ -1,0 +1,2 @@
+DB_PROVIDER="sqlite"
+DATABASE_URL="file:./dev.db"

--- a/my-app/.env.production
+++ b/my-app/.env.production
@@ -1,0 +1,3 @@
+DB_PROVIDER="postgresql"
+# Replace with your production PostgreSQL connection string
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DBNAME"

--- a/my-app/.gitignore
+++ b/my-app/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+!/.env
+!/.env.production

--- a/my-app/prisma/schema.prisma
+++ b/my-app/prisma/schema.prisma
@@ -1,0 +1,8 @@
+datasource db {
+  provider = env("DB_PROVIDER")
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}


### PR DESCRIPTION
## Summary
- add Prisma schema with env-driven datasource config
- provide sample `.env` and `.env.production` for SQLite and PostgreSQL
- unignore and commit env files for reference

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma validate` *(fails: 403 Forbidden fetching Prisma engine)*

------
https://chatgpt.com/codex/tasks/task_b_68bbcc6b302c832eac681ec981efffaa