### PR TITLE
feat: add Entry model

### DIFF
--- a/my-app/README.md
+++ b/my-app/README.md
@@ -44,3 +44,11 @@ npm run dev
 ```bash
 npm run format
 ```
+
+## Prisma コマンド
+
+```bash
+npx prisma migrate dev --name init
+npx prisma generate
+npx prisma migrate deploy
+```

--- a/my-app/prisma/migrations/20250906060034_init/migration.sql
+++ b/my-app/prisma/migrations/20250906060034_init/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "Entry" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/my-app/prisma/migrations/migration_lock.toml
+++ b/my-app/prisma/migrations/migration_lock.toml
@@ -1,0 +1,3 @@
+# This file is used by Prisma Migrate to track applied migrations.
+# It is automatically created and updated.
+provider = "sqlite"

--- a/my-app/prisma/schema.prisma
+++ b/my-app/prisma/schema.prisma
@@ -6,3 +6,11 @@ datasource db {
 generator client {
   provider = "prisma-client-js"
 }
+
+model Entry {
+  id        String   @id @default(cuid())
+  name      String
+  email     String   @db.VarChar(255)
+  message   String
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- define Entry model for form submissions
- add initial migration and usage docs

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma migrate dev --name init` *(fails: 403 Forbidden downloading schema engine)*
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` *(fails: 403 Forbidden downloading schema engine)*
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma migrate deploy` *(fails: 403 Forbidden downloading query engine)*
- `sqlite3 prisma/dev.db ".tables"`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68bbcd840268832eb613a75c5835db52