### PR TITLE
feat: add entry API route

### DIFF
--- a/my-app/src/app/api/entries/route.ts
+++ b/my-app/src/app/api/entries/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { entrySchema } from "@/lib/zod";
+
+export async function POST(request: Request) {
+  const json = await request.json();
+  const parsed = entrySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+  const entry = await prisma.entry.create({ data: parsed.data });
+  return NextResponse.json({ id: entry.id }, { status: 201 });
+}


### PR DESCRIPTION
## Summary
- implement POST /api/entries to validate request and create entry with Prisma

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bbd0214c20832e962fece8b5adc5f0