### PR TITLE
feat: add server-side config and minimal next setup

### DIFF
--- a/my-app/README.md
+++ b/my-app/README.md
@@ -52,3 +52,7 @@ npx prisma migrate dev --name init
 npx prisma generate
 npx prisma migrate deploy
 ```
+
+## Environment variables
+
+This project reads `DB_PROVIDER` and `DATABASE_URL` from the environment at runtime. They are accessed on the server via `src/lib/config.ts` and are not exposed to client-side code.

--- a/my-app/next.config.js
+++ b/my-app/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/my-app/next.config.ts
+++ b/my-app/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;

--- a/my-app/src/lib/config.ts
+++ b/my-app/src/lib/config.ts
@@ -1,0 +1,16 @@
+import "server-only";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set`);
+  }
+  return value;
+}
+
+export function getDatabaseConfig() {
+  return {
+    provider: requiredEnv("DB_PROVIDER"),
+    url: requiredEnv("DATABASE_URL"),
+  };
+}


### PR DESCRIPTION
## Summary
- add server-only helper for DB env vars
- switch to minimal `next.config.js`
- document required runtime environment variables

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bbd2b1f4e8832ea7379149cc288c39