### PR TITLE
Add Prisma helper scripts and documentation

### DIFF
--- a/my-app/README.md
+++ b/my-app/README.md
@@ -46,9 +46,10 @@ npm run format
 ```
 
 ## Prisma コマンド
+以下の npm スクリプトで Prisma 関連の操作を行えます。
 
-```bash
-npx prisma migrate dev --name init
-npx prisma generate
-npx prisma migrate deploy
-```
+- `npm run prisma:generate`: Prisma Client を生成します。
+- `npm run prisma:validate`: Prisma スキーマを検証します。
+- `npm run prisma:migrate`: 開発用のマイグレーションを作成して適用します。
+
+依存関係のインストール時（例: `npm ci`）には `postinstall` により Prisma Client が自動生成されます。

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -7,7 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prisma:generate": "prisma generate",
+    "prisma:validate": "prisma validate",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "react": "19.1.0",


### PR DESCRIPTION
## Summary
- add scripts for Prisma generate, validate, migrate and postinstall hook
- document Prisma scripts in README

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npm ci` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... 403 Forbidden)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bbd57f3fd0832ea344b108b8610282