### PR TITLE
feat: style pages with Tailwind CSS

### DIFF
--- a/my-app/app/layout.tsx
+++ b/my-app/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className="min-h-screen bg-gray-100">{children}</body>
     </html>
   );
 }

--- a/my-app/app/page.tsx
+++ b/my-app/app/page.tsx
@@ -1,14 +1,14 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 export default function Home() {
   const router = useRouter();
-  const [form, setForm] = useState({ name: '', email: '', message: '' });
+  const [form, setForm] = useState({ name: "", email: "", message: "" });
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
@@ -16,39 +16,32 @@ export default function Home() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
-      const res = await fetch('/api/entries', {
-        method: 'POST',
+      const res = await fetch("/api/entries", {
+        method: "POST",
         body: JSON.stringify(form),
       });
       if (res.ok) {
-        router.push('/thanks');
+        router.push("/thanks");
       } else {
-        alert('Submission failed');
+        alert("Submission failed");
       }
     } catch (err) {
-      alert('Submission failed');
+      alert("Submission failed");
     }
   };
 
   return (
-    <main>
+    <main className="flex min-h-screen items-center justify-center p-4">
       <form
         onSubmit={handleSubmit}
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          maxWidth: '400px',
-          margin: '0 auto',
-          padding: '16px',
-        }}
+        className="flex w-full max-w-md flex-col gap-2 rounded-lg bg-white p-6 shadow"
       >
         <input
           name="name"
           value={form.name}
           onChange={handleChange}
           placeholder="Name"
-          style={{ padding: '8px', border: '1px solid #ccc' }}
+          className="rounded border border-gray-300 p-2"
         />
         <input
           type="email"
@@ -56,23 +49,18 @@ export default function Home() {
           value={form.email}
           onChange={handleChange}
           placeholder="Email"
-          style={{ padding: '8px', border: '1px solid #ccc' }}
+          className="rounded border border-gray-300 p-2"
         />
         <textarea
           name="message"
           value={form.message}
           onChange={handleChange}
           placeholder="Message"
-          style={{ padding: '8px', border: '1px solid #ccc' }}
+          className="rounded border border-gray-300 p-2"
         />
         <button
           type="submit"
-          style={{
-            padding: '8px',
-            border: '1px solid #ccc',
-            background: '#f0f0f0',
-            cursor: 'pointer',
-          }}
+          className="rounded border border-gray-300 bg-gray-100 p-2 hover:bg-gray-200"
         >
           Send
         </button>

--- a/my-app/app/thanks/page.tsx
+++ b/my-app/app/thanks/page.tsx
@@ -1,10 +1,12 @@
-import Link from 'next/link';
+import Link from "next/link";
 
 export default function Thanks() {
   return (
-    <main>
-      <h1>送信ありがとうございます</h1>
-      <Link href="/">トップへ戻る</Link>
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4">
+      <h1 className="text-xl font-semibold">送信ありがとうございます</h1>
+      <Link href="/" className="text-blue-600 hover:underline">
+        トップへ戻る
+      </Link>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- replace inline styles with Tailwind CSS classes for cleaner layout
- add base background styling to layout
- center thank-you page with Tailwind utilities

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bbd5d26528832ea803c18b4778fd7d