### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main, pr]
+  pull_request:
+    branches: [main, pr]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: my-app
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: my-app/package-lock.json
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npx prisma validate
+      - run: npm run build
+      - run: npm run lint


### PR DESCRIPTION
## Summary
- add CI workflow running npm ci, Prisma commands, build and lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx prisma generate` *(fails: Failed to fetch sha256 checksum at https://binaries.prisma.sh/.../schema-engine.sha256 - 403 Forbidden)*
- `npx prisma validate` *(fails: Failed to fetch sha256 checksum at https://binaries.prisma.sh/.../libquery_engine.so.node.sha256 - 403 Forbidden)*
- `npm run build` *(fails: Cannot find module '@prisma/client' or its corresponding type declarations.)*

------
https://chatgpt.com/codex/tasks/task_b_68bbd5b4adf0832e8dba07b5bca43960