### PR TITLE
fix: send JSON with proper content type

### DIFF
--- a/my-app/app/page.tsx
+++ b/my-app/app/page.tsx
@@ -18,6 +18,9 @@ export default function Home() {
     try {
       const res = await fetch('/api/entries', {
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify(form),
       });
       if (res.ok) {


### PR DESCRIPTION
## Summary
- ensure contact form submission includes Content-Type header for JSON

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bbd5fd8960832ebae9d2176c0056ba