### PR TITLE
feat: add entries listing page

### DIFF
--- a/my-app/app/api/entries/route.ts
+++ b/my-app/app/api/entries/route.ts
@@ -2,6 +2,13 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { entrySchema } from "@/lib/zod";
 
+export async function GET() {
+  const entries = await prisma.entry.findMany({
+    orderBy: { createdAt: "desc" },
+  });
+  return NextResponse.json(entries);
+}
+
 export async function POST(request: Request) {
   const json = await request.json();
   const parsed = entrySchema.safeParse(json);

--- a/my-app/app/entries/page.tsx
+++ b/my-app/app/entries/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Entry {
+  id: string;
+  name: string;
+  email: string;
+  message: string;
+}
+
+export default function EntriesPage() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    fetch("/api/entries")
+      .then((res) => res.json())
+      .then((data) => setEntries(data))
+      .catch(() => setEntries([]));
+  }, []);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4">
+      <h1 className="text-xl font-semibold">Entries</h1>
+      <ul className="mt-4 w-full max-w-md">
+        {entries.length === 0 && (
+          <li className="text-sm text-gray-600">No entries found</li>
+        )}
+        {entries.map((entry) => (
+          <li key={entry.id} className="border-b py-2">
+            <p className="font-medium">{entry.name}</p>
+            <p className="text-sm text-gray-600">{entry.message}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/my-app/app/page.tsx
+++ b/my-app/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export default function Home() {
   const router = useRouter();
@@ -31,7 +32,7 @@ export default function Home() {
   };
 
   return (
-    <main className="flex min-h-screen items-center justify-center p-4">
+    <main className="flex min-h-screen flex-col items-center justify-center p-4">
       <form
         onSubmit={handleSubmit}
         className="flex w-full max-w-md flex-col gap-2 rounded-lg bg-white p-6 shadow"
@@ -65,6 +66,9 @@ export default function Home() {
           Send
         </button>
       </form>
+      <Link href="/entries" className="mt-4 text-blue-600 hover:underline">
+        View entries
+      </Link>
     </main>
   );
 }

--- a/my-app/tests/entries.spec.ts
+++ b/my-app/tests/entries.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+test("entries page shows fetched entries", async ({ page }) => {
+  await page.route("/api/entries", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "1",
+          name: "Taro",
+          email: "taro@example.com",
+          message: "Hello",
+        },
+      ]),
+    }),
+  );
+
+  await page.goto("/entries");
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Entries");
+  await expect(page.getByText("Taro")).toBeVisible();
+  await expect(page.getByText("Hello")).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- allow GET requests to fetch submitted entries
- show entry list page and link from home
- cover listing page with Playwright test

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_b_68bbd9e83f80832e89befc52797fb98a