### PR TITLE
feat: add search filter and details to entries

### DIFF
--- a/my-app/app/entries/page.tsx
+++ b/my-app/app/entries/page.tsx
@@ -7,10 +7,12 @@ interface Entry {
   name: string;
   email: string;
   message: string;
+  createdAt: string;
 }
 
 export default function EntriesPage() {
   const [entries, setEntries] = useState<Entry[]>([]);
+  const [search, setSearch] = useState("");
 
   useEffect(() => {
     fetch("/api/entries")
@@ -19,17 +21,35 @@ export default function EntriesPage() {
       .catch(() => setEntries([]));
   }, []);
 
+  const q = search.toLowerCase();
+  const filtered = entries.filter(
+    (entry) =>
+      entry.name.toLowerCase().includes(q) ||
+      entry.email.toLowerCase().includes(q) ||
+      entry.message.toLowerCase().includes(q),
+  );
+
   return (
     <main className="flex min-h-screen flex-col items-center p-4">
       <h1 className="text-xl font-semibold">Entries</h1>
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search entries"
+        className="mt-4 w-full max-w-md rounded border border-gray-300 p-2"
+      />
       <ul className="mt-4 w-full max-w-md">
-        {entries.length === 0 && (
+        {filtered.length === 0 && (
           <li className="text-sm text-gray-600">No entries found</li>
         )}
-        {entries.map((entry) => (
+        {filtered.map((entry) => (
           <li key={entry.id} className="border-b py-2">
             <p className="font-medium">{entry.name}</p>
             <p className="text-sm text-gray-600">{entry.message}</p>
+            <p className="text-sm text-gray-600">{entry.email}</p>
+            <p className="text-xs text-gray-400">
+              {new Date(entry.createdAt).toLocaleString()}
+            </p>
           </li>
         ))}
       </ul>

--- a/my-app/tests/entries.spec.ts
+++ b/my-app/tests/entries.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("entries page shows fetched entries", async ({ page }) => {
+test("entries page filters entries by search query", async ({ page }) => {
   await page.route("/api/entries", (route) =>
     route.fulfill({
       status: 200,
@@ -11,6 +11,14 @@ test("entries page shows fetched entries", async ({ page }) => {
           name: "Taro",
           email: "taro@example.com",
           message: "Hello",
+          createdAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "2",
+          name: "Jiro",
+          email: "jiro@example.com",
+          message: "World",
+          createdAt: "2024-01-02T00:00:00Z",
         },
       ]),
     }),
@@ -19,5 +27,8 @@ test("entries page shows fetched entries", async ({ page }) => {
   await page.goto("/entries");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText("Entries");
   await expect(page.getByText("Taro")).toBeVisible();
-  await expect(page.getByText("Hello")).toBeVisible();
+  await expect(page.getByText("Jiro")).toBeVisible();
+  await page.getByPlaceholder("Search entries").fill("World");
+  await expect(page.getByText("Jiro")).toBeVisible();
+  await expect(page.getByText("Taro")).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- add client-side search box to filter entries
- display email and timestamp for each entry
- test search functionality with Playwright

## Testing
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist; run npx playwright install)*
- `npx playwright install` *(fails: Download failed, server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_b_68bbdb36a644832e99f80c8b9cb48c40