### PR TITLE
Add simple calculator feature

### DIFF
--- a/my-app/app/calculator/page.tsx
+++ b/my-app/app/calculator/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+export default function CalculatorPage() {
+  const [a, setA] = useState("");
+  const [b, setB] = useState("");
+  const [result, setResult] = useState<number | null>(null);
+
+  const calculate = () => {
+    const numA = parseFloat(a);
+    const numB = parseFloat(b);
+    if (isNaN(numA) || isNaN(numB)) {
+      setResult(null);
+      return;
+    }
+    setResult(numA + numB);
+  };
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4">
+      <h1 className="text-xl font-semibold">Calculator</h1>
+      <div className="mt-4 flex w-full max-w-md flex-col gap-2">
+        <input
+          type="number"
+          value={a}
+          onChange={(e) => setA(e.target.value)}
+          placeholder="First number"
+          className="rounded border border-gray-300 p-2"
+        />
+        <input
+          type="number"
+          value={b}
+          onChange={(e) => setB(e.target.value)}
+          placeholder="Second number"
+          className="rounded border border-gray-300 p-2"
+        />
+        <button
+          onClick={calculate}
+          className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          type="button"
+        >
+          Add
+        </button>
+        {result !== null && (
+          <p className="text-lg font-medium" id="result">
+            Result: {result}
+          </p>
+        )}
+      </div>
+      <Link href="/" className="mt-4 text-blue-600 hover:underline">
+        Back to form
+      </Link>
+    </main>
+  );
+}

--- a/my-app/app/page.tsx
+++ b/my-app/app/page.tsx
@@ -73,6 +73,9 @@ export default function Home() {
         <Link href="/todo" className="text-blue-600 hover:underline">
           Todo list
         </Link>
+        <Link href="/calculator" className="text-blue-600 hover:underline">
+          Calculator
+        </Link>
       </div>
     </main>
   );

--- a/my-app/tests/calculator.spec.ts
+++ b/my-app/tests/calculator.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+test("calculator adds two numbers", async ({ page }) => {
+  await page.goto("/calculator");
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+    "Calculator",
+  );
+  await page.getByPlaceholder("First number").fill("2");
+  await page.getByPlaceholder("Second number").fill("3");
+  await page.getByRole("button", { name: "Add" }).click();
+  await expect(page.getByText("Result: 5")).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add calculator page for adding two numbers
- link calculator from home page
- test calculator addition behavior

## Testing
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist...)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_b_68bbde01cc84832e8bf07a1caf9c57b2